### PR TITLE
feat: Add drag/drop file loading

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -70,6 +70,9 @@ export default class App extends Vue {
       document.getElementById("gesture-wrapper")!.style.height = "84vh";
     }
     Mousetrap.bind("esc", () => this.ToggleLeftSideNav());
+    const $app = document.querySelector("#app");
+    $app.ondragover = this.OnDragOver;
+    $app.ondrop = this.OnFileDropped;
     // this.loadHapticsTestData();
   }
 
@@ -114,6 +117,26 @@ export default class App extends Vue {
 
   private OnDeviceDisconnected(aDevice: ButtplugClientDevice) {
     this.devices = this.devices.filter((device) => device.Index !== aDevice.Index);
+  }
+
+  private OnDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  private OnFileDropped(event: DragEvent) {
+    event.preventDefault();
+
+    if (!event.dataTransfer.items) {
+      return;
+    }
+
+    const aFile = event.dataTransfer.items[0].getAsFile();
+    const isVideoFile = /video/.test(aFile.type);
+    if (isVideoFile) {
+      this.SetVideoFile(aFile);
+    } else {
+      this.SetHapticsFile(aFile);
+    }
   }
 
   private SetVideoFile(aFile: File) {

--- a/src/App.ts
+++ b/src/App.ts
@@ -125,13 +125,15 @@ export default class App extends Vue {
 
   private OnFileDropped(event: DragEvent) {
     event.preventDefault();
-
-    if (!event.dataTransfer.items) {
+    if (!event || !event.dataTransfer) {
       return;
     }
-
     const aFile = event.dataTransfer.items[0].getAsFile();
+    if (!aFile) {
+      return;
+    }
     const isVideoFile = /video/.test(aFile.type);
+    // Load as a video file when the file MIME type matches
     if (isVideoFile) {
       this.SetVideoFile(aFile);
     } else {


### PR DESCRIPTION
Hey here's a PR for the drag/drop functionality #67 . It doesn't do anything fancy it just uses the file drag/drop API to load a video or haptics file. If the uploaded file has a video based MIME type it will slot it as a video otherwise it assumes it's a haptics file of some sort.

This is probably good for a first go. I guess it could take multiple files and try to load the haptics and video at the same time but that might be overkill.