### PR TITLE
Feature/haptics updates

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -55,6 +55,7 @@ export default class App extends Vue {
   private desiredPlayTime: number = 0;
   private currentMessages: ButtplugMessage[] = [];
   private showHapticsAlert: boolean = false;
+  private showFileDownload: boolean = false;
 
   // Buttplug properties
   private devices: ButtplugClientDevice[] = [];
@@ -189,6 +190,37 @@ export default class App extends Vue {
   private advanceFrame(currentTime: number) {
     this.currentPlayTime = currentTime;
     this.runHapticsLoop();
+  }
+
+  private onExport() {
+    if (!this.hapticsCommands.length) {
+      alert("Error: No haptics events set. \n\nPlease enter haptics into timeline before exporting.");
+    }
+
+    const actions = this.hapticsCommands.map((command) => ({
+      at: command.Time,
+      pos: command.Position,
+    }));
+    const script = {
+        version: "1.0",
+        inverted: false,
+        range: 90,
+        actions,
+    };
+
+    const file = new Blob(
+      [JSON.stringify(script)],
+      { type: "application/json" },
+    );
+    const fileURL = URL.createObjectURL(file);
+
+    this.showFileDownload = true;
+
+    setTimeout(() => {
+      const $downloadBtn = document.querySelector(".download-link");
+      $downloadBtn.setAttribute("href", fileURL);
+      $downloadBtn.setAttribute("download", "new-script.funscript");
+    }, 500);
   }
 
   private runHapticsLoop() {

--- a/src/App.ts
+++ b/src/App.ts
@@ -142,11 +142,13 @@ export default class App extends Vue {
     });
   }
 
-  private onVideoLoaded(duration: number) {
+  private onVideoLoaded(duration: number, currentTime: number) {
     if (this.hapticsCommands.length === 0) {
       this.hapticsCommands.push(new FunscriptCommand(0, 0));
       this.hapticsCommands.push(new FunscriptCommand(duration, 0));
     }
+    // seeking the time with hotkeys sends a video loaded event
+    this.advanceFrame(currentTime);
   }
 
   private onHapticsFileChange(hapticsFile: FileList) {
@@ -184,15 +186,14 @@ export default class App extends Vue {
     this.currentPlayTime = this.desiredPlayTime;
   }
 
-  private advanceFrame(direction: number) {
-    this.desiredPlayTime = (this.currentPlayTime) + (((1.0 / 60.0) * direction) * 1000);
-    this.currentPlayTime = this.desiredPlayTime;
+  private advanceFrame(currentTime: number) {
+    this.currentPlayTime = currentTime;
+    this.runHapticsLoop();
   }
 
   private runHapticsLoop() {
     window.requestAnimationFrame(() => {
-      // If we paused before this fired, just return
-      if (this.paused || this.commands.size === 0) {
+      if (this.commands.size === 0) {
         return;
       }
       // Backwards seek. Reset index retreived.

--- a/src/App.ts
+++ b/src/App.ts
@@ -54,6 +54,7 @@ export default class App extends Vue {
   private lastTimeChecked: number = 0;
   private desiredPlayTime: number = 0;
   private currentMessages: ButtplugMessage[] = [];
+  private showHapticsAlert: boolean = false;
 
   // Buttplug properties
   private devices: ButtplugClientDevice[] = [];
@@ -129,6 +130,10 @@ export default class App extends Vue {
   /////////////////////////////////////
 
   private SetHapticsFile(aFile: File) {
+    if (/html$/.test(aFile.name)) {
+      this.showBadHapticsAlert();
+      return;
+    }
     this.hapticsFile = aFile;
     LoadFile(this.hapticsFile).then((h: HapticFileHandler) => {
       this.hapticsCommands = h.Commands as FunscriptCommand[];
@@ -223,6 +228,10 @@ export default class App extends Vue {
         this.runHapticsLoop();
       }
     });
+  }
+
+  private showBadHapticsAlert() {
+    this.showHapticsAlert = true;
   }
 
   private loadHapticsTestData() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -157,6 +157,20 @@
         </v-navigation-drawer>
       </v-container>
     </v-touch>
+    <section v-if="showHapticsAlert" class="alert-modal" @click="showHapticsAlert = false">
+      <div class="alert-card">
+        <h2>Haptics File Error</h2>
+        <br>
+        <p>An HTML file was uploaded for haptics. Please make sure that you use a supported haptics file format.</p>
+        <p>Commonly used file extension for haptics are <b>.json</b>, <b>.funscript</b>, <b>.csv</b>, etc.</p>
+        <br>
+        <p>For a more complete list of accepted file formats see this page of <a href="https://stpihkal.docs.buttplug.io/video-encoding-formats/feelme.html" target="blank">Video Encoding Formats</a></p>
+        <br>
+        <button @click="showHapticsAlert = false">
+          OK
+        </button>
+      </div>
+    </section>
   </v-app>
 </template>
 
@@ -346,6 +360,32 @@
    display: flex;
    align-items: center;
    justify-content: center;
+ }
+
+ .alert-modal {
+   height: 100vh;
+   display: flex;
+   align-items: center;
+   justify-content: center;
+   z-index: 1;
+   outline: 1000vw;
+   background-color: rgba(0, 0, 0, 50%);
+ }
+
+ .alert-modal button {
+   background-color: lightgray;
+   padding: 10px 20px;
+   margin-right: 5%;
+   float: right;
+ }
+
+ .alert-modal button:hover {
+   background-color: darkgray;
+ }
+
+ .alert-card {
+   background-color: white;
+   padding: 30px;
  }
 
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -76,6 +76,7 @@
               @pause="onPause"
               @timeUpdate="onTimeUpdate"
               @inputTimeUpdate="onInputTimeUpdate"
+              @export="onExport"
               @dragStart="onDragStart"
               @dragStop="onDragStop"
             />
@@ -157,8 +158,8 @@
         </v-navigation-drawer>
       </v-container>
     </v-touch>
-    <section v-if="showHapticsAlert" class="alert-modal" @click="showHapticsAlert = false">
-      <div class="alert-card">
+    <section v-if="showHapticsAlert" class="modal" @click="showHapticsAlert = false">
+      <div class="modal-card">
         <h2>Haptics File Error</h2>
         <br>
         <p>An HTML file was uploaded for haptics. Please make sure that you use a supported haptics file format.</p>
@@ -166,9 +167,20 @@
         <br>
         <p>For a more complete list of accepted file formats see this page of <a href="https://stpihkal.docs.buttplug.io/video-encoding-formats/feelme.html" target="blank">Video Encoding Formats</a></p>
         <br>
-        <button @click="showHapticsAlert = false">
+        <button class="alert-button">
           OK
         </button>
+      </div>
+    </section>
+    <section v-if="showFileDownload" class="modal" @click="showFileDownload = false">
+      <div class="modal-card">
+        <h2>Haptics File Download</h2>
+        <br>
+        <p>Click the download button to save the file and enjoy!</p>
+        <br>
+        <a class="download-link">
+          Download
+        </a>
       </div>
     </section>
   </v-app>
@@ -362,7 +374,7 @@
    justify-content: center;
  }
 
- .alert-modal {
+ .modal {
    height: 100vh;
    display: flex;
    align-items: center;
@@ -372,18 +384,25 @@
    background-color: rgba(0, 0, 0, 50%);
  }
 
- .alert-modal button {
+ .download-link {
+   text-decoration: none;
+   color: #2c3e50;
+ }
+
+ .download-link,
+ .alert-button {
    background-color: lightgray;
    padding: 10px 20px;
    margin-right: 5%;
    float: right;
  }
 
- .alert-modal button:hover {
+ .download-link:hover,
+ .alert-button:hover {
    background-color: darkgray;
  }
 
- .alert-card {
+ .modal-card {
    background-color: white;
    padding: 30px;
  }

--- a/src/components/VideoEncoder/VideoEncoder.ts
+++ b/src/components/VideoEncoder/VideoEncoder.ts
@@ -219,7 +219,7 @@ export default class VideoEncoder extends Vue {
       .range([0, graphdiv.clientHeight]);
 
     this.xAxis = d3.axisTop(this.xScale)
-      .ticks(Math.min(this.dataExtent[1] / 1000, 50))
+      .ticks(Math.min(this.dataExtent[1] / 1000, 25))
       .tickFormat((d) => `${(d as number) / 1000}s`);
     this.yAxis = d3.axisRight(this.yScale)
       .tickSize(graphdiv.clientWidth);

--- a/src/components/VideoEncoder/VideoEncoder.ts
+++ b/src/components/VideoEncoder/VideoEncoder.ts
@@ -42,6 +42,7 @@ export default class VideoEncoder extends Vue {
     for (const i of [...Array(10).keys()]) {
       Mousetrap.bind(i.toString(), () => this.addNodeAtPoint(i * 10));
     }
+    Mousetrap.bind("backspace", () => this.removeNodeAtPoint());
     window.addEventListener("resize", this.onResize);
   }
 
@@ -49,11 +50,19 @@ export default class VideoEncoder extends Vue {
     for (const i of [...Array(10).keys()]) {
       Mousetrap.unbind(i.toString());
     }
+    Mousetrap.unbind("backspace");
     window.removeEventListener("resize", this.onResize);
   }
 
   private addNodeAtPoint(value: number) {
     // Clear any previous values at the current play time before adding the new one
+    this.removeNodeAtPoint();
+    this.hapticsValues.push([this.currentPlayTime, value]);
+    this.hapticsValues.sort((a, b) => a[0] > b[0] ? 1 : -1);
+    this.updateGraph();
+  }
+
+  private removeNodeAtPoint() {
     this.hapticsValues = this.hapticsValues.filter(([time, val]) => {
       // Remove for nodes within 999ms of the current position
       return !(
@@ -61,8 +70,6 @@ export default class VideoEncoder extends Vue {
         this.currentPlayTime + 999 >= time
       );
     });
-    this.hapticsValues.push([this.currentPlayTime, value]);
-    this.hapticsValues.sort((a, b) => a[0] > b[0] ? 1 : -1);
     this.updateGraph();
   }
 

--- a/src/components/VideoEncoder/VideoEncoder.ts
+++ b/src/components/VideoEncoder/VideoEncoder.ts
@@ -334,6 +334,10 @@ export default class VideoEncoder extends Vue {
     this.hapticsLocked = !this.hapticsLocked;
   }
 
+  private ExportHaptics() {
+    this.$emit("export");
+  }
+
   private runTimeUpdateLoop() {
     window.requestAnimationFrame(() => {
       if (!this.hapticsPlaying) {

--- a/src/components/VideoEncoder/VideoEncoder.ts
+++ b/src/components/VideoEncoder/VideoEncoder.ts
@@ -53,6 +53,14 @@ export default class VideoEncoder extends Vue {
   }
 
   private addNodeAtPoint(value: number) {
+    // Clear any previous values at the current play time before adding the new one
+    this.hapticsValues = this.hapticsValues.filter(([time, val]) => {
+      // Remove for nodes within 999ms of the current position
+      return !(
+        this.currentPlayTime - 999 <= time &&
+        this.currentPlayTime + 999 >= time
+      );
+    });
     this.hapticsValues.push([this.currentPlayTime, value]);
     this.hapticsValues.sort((a, b) => a[0] > b[0] ? 1 : -1);
     this.updateGraph();

--- a/src/components/VideoEncoder/VideoEncoder.vue
+++ b/src/components/VideoEncoder/VideoEncoder.vue
@@ -25,6 +25,10 @@
             <v-icon
               color="white" v-if="!this.hapticsLocked" title="haptics editing disabled" alt="">lock_open</v-icon>
           </li>
+          <li @click="ExportHaptics">
+            <v-icon
+              color="white" title="export haptics script" alt="">import_export</v-icon>
+          </li>
         </ul>
       </div>
     </div>

--- a/src/components/VideoEncoder/VideoEncoder.vue
+++ b/src/components/VideoEncoder/VideoEncoder.vue
@@ -9,21 +9,21 @@
         <ul>
           <li @click="ToggleHapticsPlayback">
             <v-icon
-              color="white" v-if="!this.hapticsPlaying">play_circle_outline</v-icon>
+              color="white" v-if="!this.hapticsPlaying" title="play haptics script" alt="">play_circle_outline</v-icon>
             <v-icon
-              color="white" v-if="this.hapticsPlaying">pause_circle_outline</v-icon>
+              color="white" v-if="this.hapticsPlaying" title="pause haptics script" alt="">pause_circle_outline</v-icon>
           </li>
           <li @click="ToggleHapticsLooped">
             <v-icon
-              color="white" v-if="this.hapticsLooped">sync</v-icon>
+              color="white" v-if="this.hapticsLooped" title="haptics synced" alt="">sync</v-icon>
             <v-icon
-              color="white" v-if="!this.hapticsLooped">sync_disabled</v-icon>
+              color="white" v-if="!this.hapticsLooped" title="haptics syncing disabled" alt="">sync_disabled</v-icon>
           </li>
           <li @click="ToggleHapticsLocked">
             <v-icon
-              color="white" v-if="this.hapticsLocked">lock_outline</v-icon>
+              color="white" v-if="this.hapticsLocked" title="haptics editing enabled" alt="">lock_outline</v-icon>
             <v-icon
-              color="white" v-if="!this.hapticsLocked">lock_open</v-icon>
+              color="white" v-if="!this.hapticsLocked" title="haptics editing disabled" alt="">lock_open</v-icon>
           </li>
         </ul>
       </div>
@@ -101,6 +101,7 @@
    clear: both;
    padding: 0px;
    margin: 0px;
+   z-index: 1;
  }
 
  .encoder-button-bar ul > li {

--- a/src/components/VideoPlayer/VideoPlayer.ts
+++ b/src/components/VideoPlayer/VideoPlayer.ts
@@ -123,8 +123,10 @@ export default class VideoPlayer extends Vue {
     const playerElement = (this.$refs.videoPlayer as Vue).$el;
     this.currentPlayer = (this.$refs.videoPlayer as any).player;
     this.currentPlayer!.height(document.getElementById("video-container")!.offsetHeight);
-    this.$emit("videoLoaded", this.currentPlayer!.duration() * 1000);
-    console.log(`duration: ${this.currentPlayer!.duration() * 1000}`);
+    const duration = this.currentPlayer!.duration() * 1000;
+    const currentTime = this.currentPlayer!.currentTime() * 1000;
+    this.$emit("videoLoaded", duration, currentTime);
+    console.log(`duration: ${duration}`);
     this.onHeightUpdate();
   }
 


### PR DESCRIPTION
Hi, this PR handles #64 , some of #51, and has a few smaller UI enhancements.

There are a couple screenshots for the HTML file warning showing what it looks like for mobile and desktop in #64. It could be extended to handle other file types too.

It was hard to understand what the haptics buttons were for so I added HTML title attributes to them. After hovering for a couple seconds the title message will be displayed to inform the user what the button does. Here's a screenshot of that in action with a new button.

![New Buttons](https://user-images.githubusercontent.com/3979926/99890345-b65da500-2c23-11eb-91cc-1a64ef863abc.png)

I noticed that when the video was paused multiple haptic nodes could be added to the same X coordinate on the line graph display. Since only one value can actually be set for any point in time I changed this so it clears existing values at that point before setting a new one. The time was in milliseconds so I made the window for each point 999ms but that could be shrunk down to something smaller. I wasn't sure how fast devices could move so I just left it at that, it should be easy to bump the window size down to 100ms or 250ms though.

Deletion of haptic nodes was added through a hotkey. When the graph playhead is within 999ms of a haptics node, that node gets deleted from the graph. It uses the Mousetrap library since that was already being used.

The ticks on the x-axis label of the graph were a bit scrunched together which could make it hard to read. I dropped the number of ticks down from 50 to 25 to give the tick labels more space.
Before:
![Before Haptics](https://user-images.githubusercontent.com/3979926/99890469-451ef180-2c25-11eb-8d73-4e1d56962ce5.png)

After:
![After Haptics](https://user-images.githubusercontent.com/3979926/99890471-494b0f00-2c25-11eb-9f83-560464a66a76.png)

A file export option was also added to save the current haptics commands to a Funscript file. There's a new export button for this on the haptics button area in the lower left. Clicking it will pop a modal with a download link to the file. To generate the file it basically does the opposite of what `haptic-movie-file-reader` does and saves that to an object. Then the object is put into a Blob and linked to from the download button in the modal. If no commands are loaded yet it will throw this error to make it obvious:

![Export Error](https://user-images.githubusercontent.com/3979926/99890528-ee65e780-2c25-11eb-8bfb-b64cc65e2f6d.png)

Here's what the export modal looks like in action:

![Export File](https://user-images.githubusercontent.com/3979926/99890559-29681b00-2c26-11eb-8c47-c3b610a495e2.png)

